### PR TITLE
npm i --prefer-dedupe differs from npm i && npm dedupe

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,9 +42,6 @@
   },
   "platformAutomerge": true,
   "platformCommit": "auto",
-  "postUpdateOptions": [
-    "npmDedupe"
-  ],
   "branchConcurrentLimit": 4,
   "prConcurrentLimit": 2
 }


### PR DESCRIPTION
The former prefers old versions, the latter prefers new versions -- and the former is currently breaking `npm ci` on aylett.co.uk.